### PR TITLE
Error on update failure

### DIFF
--- a/lib/spree_volume_pricing/engine.rb
+++ b/lib/spree_volume_pricing/engine.rb
@@ -83,9 +83,12 @@ module SpreeVolumePricing
           params[:variant][:volume_prices_attributes] ||= {}
         end      
         
-        update.response do |wants| 
+        update do
           wants.html do 
             redirect_to object.is_master ? volume_prices_admin_product_variant_url(object.product, object) : collection_url
+          end
+          failure.wants.html do
+            render :action => 'volume_prices'
           end
         end
 


### PR DESCRIPTION
Fixed a bug that led to an error page if the creation or update of a variant's volume_prices failed (for example because of an invalid range).
