### PR TITLE
Change display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Volume Pricing is an extension to Spree (a complete open source commerce solutio
 Each VolumePrice contains the following values:
 
 1. **Variant:** Each VolumePrice is associated with a _Variant_, which is used to link products to particular prices.
-2. **Display:** The human readable reprentation of the quantity range (Ex. 10-100).  (Optional)
+2. **Name:** The human readable reprentation of the quantity range (Ex. 10-100).  (Optional)
 3. **Range:** The quantity range for which the price is valid (See Below for Examples of Valid Ranges.)
 4. **Amount:** The price of the product if the line item quantity falls within the specified range.
 5. **Position:** Integer value for `acts_as_list` (Helps keep the volume prices in a defined order.)
@@ -24,7 +24,7 @@ Examples
 ========
 Consider the following examples of volume prices:
 
-       Variant                Display            Range        Amount         Position
+       Variant                Name               Range        Amount         Position
        -------------------------------------------------------------------------------
        Rails T-Shirt          1-5                (1..5)       19.99          1
        Rails T-Shirt          6-9                (6...10)     18.99          2

--- a/app/views/admin/variants/_edit_fields.html.erb
+++ b/app/views/admin/variants/_edit_fields.html.erb
@@ -2,7 +2,7 @@
 <table class="index">
   <thead>
     <tr>
-      <th><%= t("display") %></th>
+      <th><%= t("name") %></th>
       <th><%= t("range") %></th>
       <th><%= t("amount") %></th>
       <th><%= t("position") %></th>

--- a/app/views/admin/variants/_volume_price_fields.html.erb
+++ b/app/views/admin/variants/_volume_price_fields.html.erb
@@ -1,7 +1,7 @@
 <tr class="volume_price fields">
   <td>
-    <%= error_message_on(f.object, :display) %>
-    <%= f.text_field :display, :size => 10 %>
+    <%= error_message_on(f.object, :name) %>
+    <%= f.text_field :name, :size => 10 %>
   </td>
   <td>
     <%= error_message_on(f.object, :range) %>

--- a/app/views/admin/variants/volume_prices.html.erb
+++ b/app/views/admin/variants/volume_prices.html.erb
@@ -9,7 +9,7 @@
   <table class="index">
     <thead>
       <tr>
-        <th><%= t("display") %></th>
+        <th><%= t("name") %></th>
         <th><%= t("range") %></th>
         <th><%= t("amount") %></th>
         <th><%= t("position") %></th>

--- a/lib/generators/templates/db/migrate/20110203174010_change_display_name_for_volume_prices.rb
+++ b/lib/generators/templates/db/migrate/20110203174010_change_display_name_for_volume_prices.rb
@@ -1,0 +1,9 @@
+class ChangeDisplayNameForVolumePrices < ActiveRecord::Migration
+  def self.up
+    rename_column :volume_prices, :display, :name
+  end
+
+  def self.down
+    rename_column :volume_prices, :name, :display
+  end
+end


### PR DESCRIPTION
The Volume Price attribute "display" conflicts with the Ruby Object method "display".
Can be reproduced by looping through all @product.master.volume_prices and displaying the display attribute <%= volume_price.display %>. It will be nil for the first volume_price.
So I changed "display" to "name".
