### PR TITLE
re-add rake install task

### DIFF
--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -1,0 +1,15 @@
+namespace :spree_volume_pricing do
+  desc "Copies all migrations and assets (NOTE: This will be obsolete with Rails 3.1)"
+  task :install do
+    Rake::Task['spree_volume_pricing:install:migrations'].invoke
+  end
+
+  namespace :install do
+    desc "Copies all migrations (NOTE: This will be obsolete with Rails 3.1)"
+    task :migrations do
+      source = File.join(File.dirname(__FILE__), '..', '..', 'db')
+      destination = File.join(Rails.root, 'db')
+      Spree::FileUtilz.mirror_files(source, destination)
+    end
+  end
+end


### PR DESCRIPTION
Brian, 

I noticed that at one point there was an install rake task and a generator, but they were removed.

When working on custom_bags, I was missing the migration from this extension, so I went poking around and realized there wasn't a rake task for it.

Maybe there's some history I don't know about, but if you think it belongs here, I've provided a commit w/ the task.

thanks.
