### PR TITLE
fix typo, upgrade to edge spree, add tests 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,38 @@
+source 'http://rubygems.org'
+
+# temporarily needed until next capybara release
+gem 'selenium-webdriver', '0.2.1'
+
+group :test do
+  gem 'rspec-rails', '= 2.6.1'
+  gem 'factory_girl', '= 1.3.3'
+  gem 'factory_girl_rails', '= 1.0.1'
+  gem 'rcov'
+  gem 'shoulda'
+  gem 'faker'
+  if RUBY_VERSION < "1.9"
+    gem "ruby-debug"
+  else
+    gem "ruby-debug19"
+  end
+end
+
+group :cucumber do
+  gem 'cucumber-rails'
+  gem 'database_cleaner', '= 0.6.7'
+  gem 'nokogiri', '1.4.4'
+  gem 'capybara', '= 1.0.0'
+  gem 'factory_girl', '= 1.3.3'
+  gem 'factory_girl_rails', '= 1.0.1'
+  gem 'faker'
+  gem 'launchy'
+
+  if RUBY_VERSION < "1.9"
+    gem "ruby-debug"
+  else
+    gem "ruby-debug19"
+  end
+end
+
+gem 'spree', :git => 'git://github.com/spree/spree.git'
+gem 'spree_volume_pricing', :git => 'git://github.com/spree/spree_volume_pricing.git'

--- a/Rakefile
+++ b/Rakefile
@@ -16,3 +16,62 @@ task :release => :package do
   Rake::Gemcutter::Tasks.new(spec).define
   Rake::Task['gem:push'].invoke
 end
+
+gemfile = File.expand_path('../spec/test_app/Gemfile', __FILE__)
+if File.exists?(gemfile) && (%w(spec cucumber).include?(ARGV.first.to_s) || ARGV.size == 0)
+  require 'bundler'
+  ENV['BUNDLE_GEMFILE'] = gemfile
+  Bundler.setup
+
+  require 'rspec'
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new
+end
+
+desc "Default Task"
+task :default => [:spec ]
+
+spec = eval(File.read('spree_volume_pricing.gemspec'))
+
+Gem::PackageTask.new(spec) do |p|
+  p.gem_spec = spec
+end
+
+desc "Regenerates a rails 3 app for testing"
+task :test_app do
+  SPREE_ROOT = ENV['SPREE_ROOT']
+  raise "SPREE_ROOT should be specified (where is your source code for spree?)" unless SPREE_ROOT
+
+  require File.join(SPREE_ROOT, 'lib/generators/spree/test_app_generator')
+
+  class SpreeVolumePricingTestAppGenerator < Spree::Generators::TestAppGenerator
+
+    def install_gems
+      inside "test_app" do
+        run 'bundle exec rake spree:install'
+        run 'bundle exec rake spree_volume_pricing:install'
+      end
+    end
+
+    def migrate_db
+      run_migrations
+    end
+
+    protected
+    def full_path_for_local_gems
+      <<-gems
+gem 'spree', :path => \'#{SPREE_ROOT}\'
+gem 'spree_volume_pricing', :path => \'#{File.expand_path('..', __FILE__)}\'
+      gems
+    end
+
+  end
+  SpreeVolumePricingTestAppGenerator.start
+end
+
+namespace :test_app do
+  desc 'Rebuild test database'
+  task :rebuild_dbs do
+    system("cd spec/test_app && bundle exec rake db:drop db:migrate RAILS_ENV=test")
+  end
+end

--- a/app/controllers/admin/variants_controller_decorator.rb
+++ b/app/controllers/admin/variants_controller_decorator.rb
@@ -1,18 +1,21 @@
 Admin::VariantsController.class_eval do
-  update.before do
-    params[:variant][:volume_prices_attributes] ||= {}
-  end
+  update.before :before_update
 
   respond_override :update => {:html => {
-    :succes => lambda { redirect_to(@variant.is_master ? volume_prices_admin_product_variant_url(@variant.product, @variant) : collection_url) },
+    :success => lambda { redirect_to(@variant.is_master ? volume_prices_admin_product_variant_url(@variant.product, @variant) : collection_url) },
     :failure => lambda { redirect_to(@variant.is_master ? volume_prices_admin_product_variant_url(@variant.product, @variant) : collection_url)  } } }
 
-  def load_resource_instance 
+  def load_resource_instance
     parent
-    Variant.find(params[:id]) 
+    Variant.find(params[:id])
   end
 
   def volume_prices
     @product = @variant.product
+  end
+
+  protected
+  def before_update
+    params[:variant][:volume_prices_attributes] ||= {}
   end
 end

--- a/spec/controllers/admin/variants_controller_spec.rb
+++ b/spec/controllers/admin/variants_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Admin::VariantsController do
+  let(:user) { mock_model User }
+  before do
+    controller.stub :current_user => user
+    user.stub :has_role? => true
+  end
+
+  context "#update" do
+    it "should fire the before filter" do
+      variant = Factory(:variant)
+
+      controller.should_receive(:before_update)
+
+      put :update, {:product_id=>variant.product.permalink, :id => variant.id,:variant => variant.attributes}
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,37 +1,23 @@
-unless defined? SPREE_ROOT
-  ENV["RAILS_ENV"] = "test"
-  case
-  when ENV["SPREE_ENV_FILE"]
-    require ENV["SPREE_ENV_FILE"]
-  when File.dirname(__FILE__) =~ %r{vendor/SPREE/vendor/extensions}
-    require "#{File.expand_path(File.dirname(__FILE__) + "/../../../../../../")}/config/environment"
-  else
-    require "#{File.expand_path(File.dirname(__FILE__) + "/../../../../")}/config/environment"
-  end
-end
-require "#{SPREE_ROOT}/spec/spec_helper"
+ENV["RAILS_ENV"] ||= 'test'
+require File.expand_path("../test_app/config/environment", __FILE__)
+require 'rspec/rails'
 
-if File.directory?(File.dirname(__FILE__) + "/scenarios")
-  Scenario.load_paths.unshift File.dirname(__FILE__) + "/scenarios"
-end
-if File.directory?(File.dirname(__FILE__) + "/matchers")
-  Dir[File.dirname(__FILE__) + "/matchers/*.rb"].each {|file| require file }
+#include spree's factories
+require 'spree_core'
+require 'spree_core/testing_support/factories'
+
+# include local factories
+Dir["#{File.dirname(__FILE__)}/factories/**/*.rb"].each do |f|
+  fp =  File.expand_path(f)
+  require fp
 end
 
-Spec::Runner.configure do |config|
-  # config.use_transactional_fixtures = true
-  # config.use_instantiated_fixtures  = false
-  # config.fixture_path = RAILS_ROOT + '/spec/fixtures'
+# Requires supporting ruby files with custom matchers and macros, etc,
+# in spec/support/ and its subdirectories.
+Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
-  # You can declare fixtures for each behaviour like this:
-  #   describe "...." do
-  #     fixtures :table_a, :table_b
-  #
-  # Alternatively, if you prefer to declare them only once, you can
-  # do so here, like so ...
-  #
-  #   config.global_fixtures = :table_a, :table_b
-  #
-  # If you declare global fixtures, be aware that they will be declared
-  # for all of your examples, even those that don't use them.
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+  config.use_transactional_fixtures = true
 end


### PR DESCRIPTION
Handful of updates here for the edge spree upgrade.

1) Updated controller/admin/variants_controller_decorator
   a) fixed a typo :succes => :success
   b) updated the r_c piece

2) I overhauled spec_helper.  It looks like there was a developer-specific version, so I standardized to use 'test_app' (I provied a test_app rake task as well).   Of course I don't want to step on anyone's toes, so if that other path info was there for good reason, feel free to toss my updates.

3) I provided a passing test for my controller change.  Many of the existing tests fail, but I'm thinking they were already failing, and I can look at those next.  They had nothing to do w/ my changes.
