### PR TITLE
Fix for new variant trying to load resource/before callback change

### DIFF
--- a/app/controllers/admin/variants_controller_decorator.rb
+++ b/app/controllers/admin/variants_controller_decorator.rb
@@ -5,11 +5,6 @@ Admin::VariantsController.class_eval do
     :success => lambda { redirect_to(@variant.is_master ? volume_prices_admin_product_variant_url(@variant.product, @variant) : collection_url) },
     :failure => lambda { redirect_to(@variant.is_master ? volume_prices_admin_product_variant_url(@variant.product, @variant) : collection_url)  } } }
 
-  def load_resource_instance
-    parent
-    Variant.find(params[:id])
-  end
-
   def volume_prices
     @product = @variant.product
   end


### PR DESCRIPTION
Merged spree/spree_volume_pricing/master and jsqu99 edge-rails for edge spree compatibility.
Feel free to merge off jsqu99 instead, I just performed the merge because saw a bug was open so I submitted a request.

remove load_resource_instance as it was loading even on 'new' and preventing adding a new variant
https://github.com/jsqu99/spree_volume_pricing/commit/1c889818da65ecacb5a573c6d7c4236f8a4dea51

update.before no longer takes a block, changed in 

app/controllers/admin/variants_controller_decorator.rb @ 7cf7a55

https://github.com/spree/spree_volume_pricing/issues/10

Thanks,

Chris
