### PR TITLE
Enable delete of volume pricing (Rails 3.0.9) 

### DIFF
--- a/app/models/variant_decorator.rb
+++ b/app/models/variant_decorator.rb
@@ -1,6 +1,6 @@
 Variant.class_eval do 
   has_many :volume_prices, :order => :position, :dependent => :destroy
-  accepts_nested_attributes_for :volume_prices
+  accepts_nested_attributes_for :volume_prices, :allow_destroy => true
 
   # calculates the price based on quantity
   def volume_price(quantity)


### PR DESCRIPTION
 accepts_nested_attributes_for  _destroy no longer works on Rails 3.0.9
