### PR TITLE
namespace changes, locales and range without brackets

### DIFF
--- a/app/controllers/spree/admin/variants_controller_decorator.rb
+++ b/app/controllers/spree/admin/variants_controller_decorator.rb
@@ -9,7 +9,7 @@ Spree::Admin::VariantsController.class_eval do
     if new_actions.include?(params[:action].to_sym)
       build_resource
     elsif params[:id]
-      Variant.find(params[:id])
+      ::Spree::Variant.find(params[:id])
     end
   end
 

--- a/app/models/spree/volume_price.rb
+++ b/app/models/spree/volume_price.rb
@@ -2,11 +2,11 @@ class Spree::VolumePrice < ActiveRecord::Base
   belongs_to :variant
   acts_as_list :scope => :variant
 
-  validates :range, :format => {:with => /\([0-9]+(?:\.{2,3}[0-9]+|\+\))/, :message => "must be in one of the following formats: (a..b), (a...b), (a+)"}
+  validates :range, :format => {:with => /\(?[0-9]+(?:\.{2,3}[0-9]+|\+\)?)/, :message => "must be in one of the following formats: (a..b), (a...b), (a+)"}
   validates_presence_of :variant
   validates_presence_of :amount
   
-  OPEN_ENDED = /\([0-9]+\+\)/
+  OPEN_ENDED = /\(?[0-9]+\+\)?/
   
   def include?(quantity)
     if open_ended?

--- a/app/overrides/views_decorator.rb
+++ b/app/overrides/views_decorator.rb
@@ -1,11 +1,11 @@
-Deface::Override.new(:virtual_path => "admin/shared/_product_tabs",
+Deface::Override.new(:virtual_path => "spree/admin/shared/_product_tabs",
                      :name => "add_volume_pricing_admin_tab",
                      :insert_bottom => "[data-hook='admin_product_tabs']",
-                     :partial => "admin/shared/vp_product_tab",
+                     :partial => "spree/admin/shared/vp_product_tab",
                      :disabled => false)
 
-Deface::Override.new(:virtual_path => "admin/variants/edit",
+Deface::Override.new(:virtual_path => "spree/admin/variants/edit",
                      :name => "add_volume_pricing_field_to_variant",
                      :insert_after => "[data-hook='admin_variant_edit_form']",
-                     :partial => "admin/variants/edit_fields",
+                     :partial => "spree/admin/variants/edit_fields",
                      :disabled => false)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,7 @@
+---
+de:
+  add_volume_price: Neuen Staffelpreis
+  position: Position
+  range: Bereich
+  volume_prices: Staffelpreise
+  volume_pricing: Staffelpreis


### PR DESCRIPTION
fixed a few namespace issues,
added german locales
i stumbled upon entering ranges without brackets - and i assume i am not alone with this - so i changed the regex to allow bracket-less input too
