### PR TITLE
Update app/views/spree/admin/variants/volume_prices.html.erb

### DIFF
--- a/app/views/spree/admin/variants/volume_prices.html.erb
+++ b/app/views/spree/admin/variants/volume_prices.html.erb
@@ -20,7 +20,7 @@
       <% end %>
     </tbody>
   </table>
-  <%= link_to_add_fields icon('add') + ' ' + t("add_volume_price"), "tbody#volume_prices", f, :volume_prices %>
+  <%= link_to_add_fields t("add_volume_price"), "tbody#volume_prices" %>
   <br/><br/>
 
   <%= render 'spree/admin/shared/edit_resource_links' %>


### PR DESCRIPTION
I needed this change to get it to work on spree 1.1 the method  link_to_add_fields seems to have changed
