### PR TITLE
Fixed admin view

### DIFF
--- a/app/views/spree/admin/variants/volume_prices.html.erb
+++ b/app/views/spree/admin/variants/volume_prices.html.erb
@@ -20,7 +20,7 @@
       <% end %>
     </tbody>
   </table>
-  <%= link_to_add_fields icon('add') + ' ' + t("add_volume_price"), "tbody#volume_prices", f, :volume_prices %>
+  <%= link_to_add_fields t("add_volume_price"), "tbody#volume_prices" %>
   <br/><br/>
 
   <%= render 'spree/admin/shared/edit_resource_links' %>


### PR DESCRIPTION
it seems that some deprecated version of link_to_add_fields with 4 arguments was used:

= link_to_add_fields t("add_volume_price"), "tbody#volume_prices"

Nice gem, by the way.
