### PR TITLE
Fixed a dependency that broke in Spree 1.1.2

### DIFF
--- a/app/views/spree/admin/variants/_edit_fields.html.erb
+++ b/app/views/spree/admin/variants/_edit_fields.html.erb
@@ -15,6 +15,7 @@
     <% end %>
   </tbody>
 </table>
-<%= link_to_add_fields icon('add') + ' ' + t("add_volume_price"), "tbody#volume_prices", f, :volume_prices %>
+
+<%= link_to icon('add') + t("add_volume_price"), 'javascript:', :data => { :target => "tbody#volume_prices" }, :class => "add_fields" %>
 <br/><br/>
 

--- a/app/views/spree/admin/variants/volume_prices.html.erb
+++ b/app/views/spree/admin/variants/volume_prices.html.erb
@@ -20,7 +20,7 @@
       <% end %>
     </tbody>
   </table>
-  <%= link_to_add_fields icon('add') + ' ' + t("add_volume_price"), "tbody#volume_prices", f, :volume_prices %>
+  <%= link_to icon('add') + t("add_volume_price"), 'javascript:', :data => { :target => "tbody#volume_prices" }, :class => "add_fields" %>
   <br/><br/>
 
   <%= render 'spree/admin/shared/edit_resource_links' %>


### PR DESCRIPTION
The base helper in spree_core, link_to_add_fields, had changed in Spree 1.1.2.  Code was updated to use a standard link_to instead of the helper so that it will continue to work with 1.1.x.
