### PR TITLE
Update app/models/spree/line_item_decorator.rb

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -7,7 +7,8 @@ Spree::LineItem.class_eval do
 
   old_copy_price = instance_method(:copy_price)
   define_method(:copy_price) do
-    new_price = old_copy_price.bind(self).call
+    old_copy_price.bind(self).call
+    new_price = self.price
 
     if variant and changed? and changes.keys.include? 'quantity'
       vprice = self.variant.volume_price(self.quantity)


### PR DESCRIPTION
Fixes #36 the method copy_price returns a currency string and updates self.price
so the return value is of no use any more
