### PR TITLE
fixes add-fields to allow select (vs. just input)

### DIFF
--- a/app/assets/javascripts/admin/spree_volume_pricing.js
+++ b/app/assets/javascripts/admin/spree_volume_pricing.js
@@ -1,0 +1,24 @@
+// spree's version only handles 'input', not 'select', and this breaks spree_volume_pricing
+
+$(function () {
+  $('.new_volume_price_row.add_fields').off('click').on('click', function() {
+    var target = $(this).data("target");
+    var new_table_row = $(target + ' tr:visible:last').clone();
+    var new_id = new Date().getTime();
+    new_table_row.find("input,select").each(function () {
+      var el = $(this);
+      el.val("");
+      el.attr("id", el.attr("id").replace(/\d+/, new_id))
+      el.attr("name", el.attr("name").replace(/\d+/, new_id))
+    });
+    // When cloning a new row, set the href of all icons to be an empty "#"
+    // This is so that clicking on them does not perform the actions for the
+    // duplicated row
+    new_table_row.find("a").each(function () {
+      var el = $(this);
+      el.attr('href', '#');
+    });
+    $(target).prepend(new_table_row);
+  });
+
+});

--- a/app/views/spree/admin/variants/volume_prices.html.erb
+++ b/app/views/spree/admin/variants/volume_prices.html.erb
@@ -21,7 +21,7 @@
       <% end %>
     </tbody>
   </table>
-  <%= link_to_add_fields t("add_volume_price"), "tbody#volume_prices" %>
+  <%= link_to_add_fields t("add_volume_price"), "tbody#volume_prices", {:class => 'new_volume_price_row'} %>
   <br/><br/>
 
   <%= render 'spree/admin/shared/edit_resource_links' %>

--- a/lib/generators/spree_volume_pricing/install_generator.rb
+++ b/lib/generators/spree_volume_pricing/install_generator.rb
@@ -1,6 +1,11 @@
 module SpreeVolumePricing
   module Generators
     class InstallGenerator < Rails::Generators::Base
+
+      def add_javascripts
+        append_file "app/assets/javascripts/admin/all.js", "//= require admin/spree_volume_pricing\n"
+      end
+
       def add_migrations
         run 'rake railties:install:migrations FROM=spree_volume_pricing'
       end


### PR DESCRIPTION
I'm not sure if this belongs in spree or just this extension, but the add-fields javascript https://github.com/spree/spree/blob/1-3-stable/core/app/assets/javascripts/admin/admin.js.erb#L160 only handles 'input', which means the pricing select box doesn't get the right id, which causes the 'add' to fail.
