### PR TITLE
A change was made recently to spree for multi-currency.

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -10,17 +10,18 @@ Spree::LineItem.class_eval do
   define_method(:copy_price) do
     old_copy_price.bind(self).call
 
-    if variant && changed? && changes.keys.include?('quantity')
-      vprice = self.variant.volume_price(self.quantity)
+    if variant
+      if changed? && changes.keys.include?('quantity')
+        vprice = self.variant.volume_price(self.quantity)
 
-      if self.price.present? && vprice <= self.variant.price
-        self.price = vprice and return
+        if self.price.present? && vprice <= self.variant.price
+          self.price = vprice and return
+        end
       end
-    end
 
-    if self.price.nil?
-      self.price = self.variant.price
+      if self.price.nil?
+        self.price = self.variant.price
+      end
     end
   end
 end
-


### PR DESCRIPTION
The copy_price method used to return the price:
https://github.com/spree/spree/commit/58ec5cd5124e66c60811a075b290248962159f9e#L12L27

but it no longer does, so we must not rely on its return value in our 'overridden' method.

The tests are currently failing (before my request), but this fixes several. 

I'm requesting a thorough review of my changes just to be safe as I'm not sure that some of the existing code was necessary/correct.

Also, please cherry pick to master as well
