### PR TITLE
Fixes a test for >1 volume pricing match

### DIFF
--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -29,7 +29,7 @@ describe Spree::Order do
 
     it "should use the first matching volume price in the event of more then one matching volume prices" do
       @order.add_variant(@variant_with_prices, 5)
-      @order.line_items.first.price.should == 9
+      @order.line_items.first.price.should == 8
     end
   end
 end


### PR DESCRIPTION
Looks like this test was already fixed in 2.1-Stable. Just porting it back to the 2.0 branch.

https://github.com/spree/spree_volume_pricing/blob/2-1-stable/spec/models/spree/order_spec.rb#L30-32
