### PR TITLE
I believe your calculations are incorrect, professor monkey patch.

### DIFF
--- a/lib/spree_volume_pricing/engine.rb
+++ b/lib/spree_volume_pricing/engine.rb
@@ -9,15 +9,15 @@ module SpreeVolumePricing
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
 
-      String.class_eval do 
+      String.class_eval do
         def to_range
           case self.count('.')
           when 2
             elements = self.split('..')
-            return Range.new(elements[0].from(1).to_i, elements[1].to_i)
+            return Range.new(elements[0].to_i, elements[1].to_i)
           when 3
             elements = self.split('...')
-            return Range.new(elements[0].from(1).to_i, elements[1].to_i-1)
+            return Range.new(elements[0].to_i, elements[1].to_i-1)
           else
             raise ArgumentError.new("Couldn't convert to Range: #{self}")
           end


### PR DESCRIPTION
Fix faulty implementation of String#to_range.

``` ruby
"10..50".to_range
# => 0..50
```

I think not.

Culprit: https://github.com/spree/spree_volume_pricing/blob/master/lib/spree_volume_pricing/engine.rb#L17-L20

For some inexplicable reason the to_range method is excluding the first character of the range start. "501" becomes "01" and "10" becomes "0".

Anyways I believe I've fixed it.
