### PR TITLE
Roles with master variant as template

### DIFF
--- a/app/helpers/spree/base_helper_decorator.rb
+++ b/app/helpers/spree/base_helper_decorator.rb
@@ -1,13 +1,13 @@
 Spree::BaseHelper.class_eval do
-  def display_volume_price(variant, quantity = 1)
-    Spree::Money.new(variant.volume_price(quantity), { currency: Spree::Config[:currency] }).to_html
+  def display_volume_price(variant, quantity = 1, user=nil)
+    Spree::Money.new(variant.volume_price(quantity, user), { currency: Spree::Config[:currency] }).to_html
   end
 
-  def display_volume_price_earning_percent(variant, quantity = 1)
-    variant.volume_price_earning_percent(quantity).round.to_s
+  def display_volume_price_earning_percent(variant, quantity = 1, user=nil)
+    variant.volume_price_earning_percent(quantity, user).round.to_s
   end
 
-  def display_volume_price_earning_amount(variant, quantity = 1)
-    Spree::Money.new(variant.volume_price_earning_amount(quantity), { currency: Spree::Config[:currency] }).to_html
+  def display_volume_price_earning_amount(variant, quantity = 1, user=nil)
+    Spree::Money.new(variant.volume_price_earning_amount(quantity, user), { currency: Spree::Config[:currency] }).to_html
   end
 end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -12,7 +12,11 @@ Spree::LineItem.class_eval do
 
     if variant
       if changed? && changes.keys.include?('quantity')
-        vprice = self.variant.volume_price(self.quantity, self.order.user)
+        if self.variant.volume_prices.empty? && !self.product.master.volume_prices.empty? && Spree::Config.use_master_variant_volume_pricing
+          vprice = self.product.master.volume_price(self.quantity, self.order.user)
+        else
+          vprice = self.variant.volume_price(self.quantity, self.order.user)
+        end
 
         if self.price.present? && vprice <= self.variant.price
           self.price = vprice and return

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -12,7 +12,7 @@ Spree::LineItem.class_eval do
 
     if variant
       if changed? && changes.keys.include?('quantity')
-        vprice = self.variant.volume_price(self.quantity)
+        vprice = self.variant.volume_price(self.quantity, self.order.user)
 
         if self.price.present? && vprice <= self.variant.price
           self.price = vprice and return

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -6,11 +6,15 @@ Spree::Variant.class_eval do
     }
 
   # calculates the price based on quantity
-  def volume_price(quantity)
+  def volume_price(quantity, user=nil)
     if self.volume_prices.count == 0
       return self.price
     else
       self.volume_prices.each do |volume_price|
+        if volume_price.spree_role
+          return self.price unless user
+          return self.price unless user.has_spree_role? volume_price.spree_role.name.to_sym
+        end
         if volume_price.include?(quantity)
           case volume_price.discount_type
           when 'price'
@@ -28,11 +32,15 @@ Spree::Variant.class_eval do
   end
 
   # return percent of earning
-  def volume_price_earning_percent(quantity)
+  def volume_price_earning_percent(quantity, user=nil)
     if self.volume_prices.count == 0
       return 0
     else
       self.volume_prices.each do |volume_price|
+        if volume_price.spree_role
+          return 0 unless user
+          return 0 unless user.has_spree_role? volume_price.spree_role.name.to_sym
+        end
         if volume_price.include?(quantity)
           case volume_price.discount_type
           when 'price'
@@ -51,11 +59,15 @@ Spree::Variant.class_eval do
   end
 
   # return amount of earning
-  def volume_price_earning_amount(quantity)
+  def volume_price_earning_amount(quantity, user=nil)
     if self.volume_prices.count == 0
       return 0
     else
       self.volume_prices.each do |volume_price|
+        if volume_price.spree_role
+          return 0 unless user
+          return 0 unless user.has_spree_role? volume_price.spree_role.name.to_sym
+        end
         if volume_price.include?(quantity)
           case volume_price.discount_type
           when 'price'

--- a/app/models/spree/volume_price.rb
+++ b/app/models/spree/volume_price.rb
@@ -1,5 +1,6 @@
 class Spree::VolumePrice < ActiveRecord::Base
   belongs_to :variant, touch: true
+  belongs_to :spree_role, class_name: "Spree::Role", foreign_key: "role_id"
   acts_as_list scope: :variant
 
   validates :amount, presence: true

--- a/app/views/spree/admin/variants/_edit_fields.html.erb
+++ b/app/views/spree/admin/variants/_edit_fields.html.erb
@@ -14,6 +14,7 @@
       <th><%= Spree.t(:range) %></th>
       <th><%= Spree.t(:amount) %></th>
       <th><%= Spree.t(:position) %></th>
+      <th><%= Spree.t(:role) %></th>
       <th><%= Spree.t(:action) %></th>
     </tr>
   </thead>

--- a/app/views/spree/admin/variants/_volume_price_fields.html.erb
+++ b/app/views/spree/admin/variants/_volume_price_fields.html.erb
@@ -23,6 +23,10 @@
     <%= error_message_on(f.object, :position) %>
     <%= f.text_field :position, size: 3, class: 'form_control' %>
   </td>
+  <td>
+    <%= error_message_on(f.object, :role_id) %>
+    <%= f.select :role_id, Spree::Role.all.collect { |r| [ r.name, r.id ] }, include_blank: true, size: 3, class: 'form_control' %>
+  </td>
   <td class="actions">
     <%= link_to_icon_remove_fields f %>
   </td>

--- a/db/migrate/20150513200904_add_role_to_volume_price.rb
+++ b/db/migrate/20150513200904_add_role_to_volume_price.rb
@@ -1,0 +1,5 @@
+class AddRoleToVolumePrice < ActiveRecord::Migration
+  def change
+    add_column :spree_volume_prices, :role_id, :integer
+  end
+end

--- a/lib/spree_volume_pricing/engine.rb
+++ b/lib/spree_volume_pricing/engine.rb
@@ -4,6 +4,12 @@ module SpreeVolumePricing
     isolate_namespace Spree
     engine_name 'spree_volume_pricing'
 
+    initializer "spree_volume_pricing.preferences", before: "spree.environment" do |app|
+      Spree::AppConfiguration.class_eval do
+        preference :use_master_variant_volume_pricing, :boolean, :default => false
+      end
+    end
+
     def self.activate
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -5,11 +5,29 @@ RSpec.describe Spree::LineItem, type: :model do
     @variant.volume_prices.create! amount: 9, discount_type: 'price', range: '(2+)'
     @order.contents.add(@variant, 1)
     @line_item = @order.line_items.first
+    @role = create(:role)
   end
 
-  it 'updates the line item price when the quantity changes to match a range' do
+  it 'updates the line item price when the quantity changes to match a range and has no role' do
     expect(@line_item.price.to_f).to be(10.00)
     @order.contents.add(@variant, 1)
     expect(@order.line_items.first.price.to_f).to be(9.00)
+  end
+
+  it 'updates the line item price when the quantity changes to match a range and role matches' do
+    @order.user.spree_roles << @role
+    expect(@order.user.has_spree_role? @role.name.to_sym).to be(true)
+    @variant.volume_prices.first.update(role_id: @role.id)
+    expect(@line_item.price.to_f).to be(10.00)
+    @order.contents.add(@variant, 1)
+    expect(@order.line_items.first.price.to_f).to be(9.00)
+  end
+
+  it 'does not update the line item price when the variant role and order role don`t match' do
+    expect(@order.user.has_spree_role? @role.name.to_sym).to be(false)
+    @variant.volume_prices.first.update(role_id: @role.id)
+    expect(@line_item.price.to_f).to be(10.00)
+    @order.contents.add(@variant, 1)
+    expect(@order.line_items.first.price.to_f).to be(10.00)
   end
 end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -29,5 +29,21 @@ RSpec.describe Spree::Order, type: :model do
       @order.contents.add(@variant_with_prices, 5)
       expect(@order.line_items.first.price).to eq(8)
     end
+
+    it 'uses the master variant volume price in case variant has no volume price if config is true' do
+      Spree::Config.use_master_variant_volume_pricing = true
+      @master = @variant.product.master
+      @master.volume_prices << create(:volume_price, range: '(1..5)', amount: 9, position: 2)
+      @order.contents.add(@variant, 5)
+      expect(@order.line_items.first.price).to eq(9)
+    end
+
+    it 'doesnt use the master variant volume price in case variant has no volume price if config is false' do
+      Spree::Config.use_master_variant_volume_pricing = false
+      @master = @variant.product.master
+      @master.volume_prices << create(:volume_price, range: '(1..5)', amount: 9, position: 2)
+      @order.contents.add(@variant, 5)
+      expect(@order.line_items.first.price).to eq(10)
+    end
   end
 end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -4,101 +4,275 @@ RSpec.describe Spree::Variant, type: :model do
   describe '#volume_price' do
 
     context 'discount_type = price' do
-      before do
+      before :each do
         @variant = create :variant, price: 10
         @variant.volume_prices.create! amount: 9, discount_type: 'price', range: '(10+)'
+        @role = create(:role)
+        @user = create(:user)
       end
 
       it 'uses the variants price when it does not match a range' do
         expect(@variant.volume_price(1).to_f).to be(10.00)
       end
 
+      it 'uses the variants price when it does not match role with null role' do
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price(10).to_f).to be(10.00)
+      end
+
+      it 'uses the variants price when it does not match roles' do
+        other_role = create(:role)
+        @user.spree_roles << other_role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price(10, @user).to_f).to be(10.00)
+      end
+
       it 'uses the volume price when it does match a range' do
         expect(@variant.volume_price(10).to_f).to be(9.00)
       end
 
-      it 'gives percent of earning' do
+      it 'uses the volume price when it does match a range and role' do
+        @user.spree_roles << @role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price(10, @user).to_f).to be(9.00)
+      end
+
+      it 'gives percent of earning without role' do
         expect(@variant.volume_price_earning_percent(10)).to be(10)
+      end
+
+      it 'gives percent of earning if role matches' do
+        @user.spree_roles << @role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_percent(10, @user)).to be(10)
       end
 
       it 'gives zero percent earning if doesnt match' do
         expect(@variant.volume_price_earning_percent(1)).to be(0)
       end
 
-      it 'gives amount earning' do
+      it 'gives zero percent earning if role doesnt match with null' do
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_percent(10)).to be(0)
+      end
+
+      it 'gives zero percent earning if role doesnt match' do
+        other_role = create(:role)
+        @user.spree_roles << other_role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_percent(10, @user)).to be(0)
+      end
+
+      it 'gives amount earning without role' do
         expect(@variant.volume_price_earning_amount(10)).to eq(1)
+      end
+
+      it 'gives amount earning if role matches' do
+        @user.spree_roles << @role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_amount(10, @user)).to eq(1)
       end
 
       it 'gives zero earning amount if doesnt match' do
         expect(@variant.volume_price_earning_amount(1)).to eq(0)
+      end
+
+      it 'gives zero earning amount if role doesnt match with null' do
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_amount(10)).to be(0)
+      end
+
+      it 'gives zero earning amount if role doesnt match' do
+        other_role = create(:role)
+        @user.spree_roles << other_role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_amount(10, @user)).to be(0)
       end
     end
 
     context 'discount_type = dollar' do
-      before do
+      before :each do
         @variant = create :variant, price: 10
         @variant.volume_prices.create! amount: 1, discount_type: 'dollar', range: '(10+)'
+        @role = create(:role)
+        @user = create(:user)
       end
 
       it 'uses the variants price when it does not match a range' do
         expect(@variant.volume_price(1).to_f).to be(10.00)
       end
 
+      it 'uses the variants price when it does not match role with null role' do
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price(10).to_f).to be(10.00)
+      end
+
+      it 'uses the variants price when it does not match roles' do
+        other_role = create(:role)
+        @user.spree_roles << other_role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price(10, @user).to_f).to be(10.00)
+      end
+
       it 'uses the volume price when it does match a range' do
         expect(@variant.volume_price(10).to_f).to be(9.00)
       end
 
-      it 'gives percent of earning' do
+      it 'uses the volume price when it does match a range and role' do
+        @user.spree_roles << @role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price(10, @user).to_f).to be(9.00)
+      end
+
+      it 'gives percent of earning without role' do
         expect(@variant.volume_price_earning_percent(10)).to be(10)
+      end
+
+      it 'gives percent of earning if role matches' do
+        @user.spree_roles << @role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_percent(10, @user)).to be(10)
       end
 
       it 'gives zero percent earning if doesnt match' do
         expect(@variant.volume_price_earning_percent(1)).to be(0)
       end
 
-      it 'gives amount earning' do
+      it 'gives zero percent earning if role doesnt match with null' do
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_percent(10)).to be(0)
+      end
+
+      it 'gives zero percent earning if role doesnt match' do
+        other_role = create(:role)
+        @user.spree_roles << other_role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_percent(10, @user)).to be(0)
+      end
+
+      it 'gives amount earning without role' do
         expect(@variant.volume_price_earning_amount(10)).to eq(1)
+      end
+
+      it 'gives amount earning if role matches' do
+        @user.spree_roles << @role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_amount(10, @user)).to eq(1)
       end
 
       it 'gives zero earning amount if doesnt match' do
         expect(@variant.volume_price_earning_amount(1)).to eq(0)
       end
+
+      it 'gives zero earning amount if role doesnt match with null' do
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_amount(10)).to be(0)
+      end
+
+      it 'gives zero earning amount if role doesnt match' do
+        other_role = create(:role)
+        @user.spree_roles << other_role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_amount(10, @user)).to be(0)
+      end
     end
 
     context 'discount_type = percent' do
-      before do
+      before :each do
         @variant = create :variant, price: 10
         @variant.volume_prices.create! amount: 0.1, discount_type: 'percent', range: '(10+)'
+        @role = create(:role)
+        @user = create(:user)
       end
 
       it 'uses the variants price when it does not match a range' do
         expect(@variant.volume_price(1).to_f).to be(10.00)
       end
 
+      it 'uses the variants price when it does not match role with null role' do
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price(10).to_f).to be(10.00)
+      end
+
+      it 'uses the variants price when it does not match roles' do
+        other_role = create(:role)
+        @user.spree_roles << other_role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price(10, @user).to_f).to be(10.00)
+      end
+
       it 'uses the volume price when it does match a range' do
         expect(@variant.volume_price(10).to_f).to be(9.00)
       end
 
-      it 'gives percent of earning' do
+      it 'uses the volume price when it does match a range and role' do
+        @user.spree_roles << @role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price(10, @user).to_f).to be(9.00)
+      end
+
+      it 'gives percent of earning without roles' do
         expect(@variant.volume_price_earning_percent(10)).to be(10)
         @variant_five = create :variant, price: 10
         @variant_five.volume_prices.create! amount: 0.5, discount_type: 'percent', range: '(1+)'
         expect(@variant_five.volume_price_earning_percent(1)).to be(50)
       end
 
+      it 'gives amount earning if role matches' do
+        @user.spree_roles << @role
+        expect(@variant.volume_price_earning_percent(10)).to be(10)
+        @variant_five = create :variant, price: 10
+        @variant_five.volume_prices.create! amount: 0.5, discount_type: 'percent', range: '(1+)'
+        @variant_five.volume_prices.first.update(role_id: @role.id)
+        expect(@variant_five.volume_price_earning_percent(1, @user)).to be(50)
+      end
+
       it 'gives zero percent earning if doesnt match' do
         expect(@variant.volume_price_earning_percent(1)).to be(0)
       end
 
-      it 'gives amount earning' do
+      it 'gives zero percent earning if role doesnt match with null' do
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_percent(10)).to be(0)
+      end
+
+      it 'gives zero percent earning if role doesnt match' do
+        other_role = create(:role)
+        @user.spree_roles << other_role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_percent(10, @user)).to be(0)
+      end
+
+      it 'gives amount earning without roles' do
         expect(@variant.volume_price_earning_amount(10)).to eq(1)
         @variant_five = create :variant, price: 10
         @variant_five.volume_prices.create! amount: 0.5, discount_type: 'percent', range: '(1+)'
         expect(@variant_five.volume_price_earning_amount(1)).to eq(5)
       end
 
+      it 'gives amount earning if role matches' do
+        @user.spree_roles << @role
+        expect(@variant.volume_price_earning_amount(10)).to eq(1)
+        @variant_five = create :variant, price: 10
+        @variant_five.volume_prices.create! amount: 0.5, discount_type: 'percent', range: '(1+)'
+        @variant_five.volume_prices.first.update(role_id: @role.id)
+        expect(@variant_five.volume_price_earning_amount(1, @user)).to eq(5)
+      end
+
       it 'gives zero earning amount if doesnt match' do
         expect(@variant.volume_price_earning_amount(1)).to eq(0)
+      end
+
+      it 'gives zero earning amount if role doesnt match with null' do
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_amount(10)).to be(0)
+      end
+
+      it 'gives zero earning amount if role doesnt match' do
+        other_role = create(:role)
+        @user.spree_roles << other_role
+        @variant.volume_prices.first.update(role_id: @role.id)
+        expect(@variant.volume_price_earning_amount(10, @user)).to be(0)
       end
     end
   end

--- a/spec/models/spree/volume_price_spec.rb
+++ b/spec/models/spree/volume_price_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Spree::VolumePrice, type: :model do
   it { is_expected.to belong_to(:variant) }
+  it { is_expected.to belong_to(:spree_role) }
   it { is_expected.to validate_presence_of(:variant) }
   it { is_expected.to validate_presence_of(:amount) }
 


### PR DESCRIPTION
This is the continuation of #75 where we are able to use the master variant as the template for all empty variants of a product.