### PR TITLE
Makes the to_range method work with or without parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Volume Pricing is an extension to Spree (a complete open source commerce solutio
 Each VolumePrice contains the following values:
 
 1. **Variant:** Each VolumePrice is associated with a _Variant_, which is used to link products to particular prices.
-1. **Name:** The human readable reprentation of the quantity range (Ex. 10-100).  (Optional)
+1. **Name:** The human readable representation of the quantity range (Ex. 10-100).  (Optional)
 1. **Discount Type** The type of discount to apply.  **Price:** sets price to the amount specified. **Dollar:** subtracts specified amount from the Variant price.  **Percent:** subtracts the specified amounts percentage from the Variant price.
 1. **Range:** The quantity range for which the price is valid (See Below for Examples of Valid Ranges.)
 1. **Amount:** The price of the product if the line item quantity falls within the specified range.
@@ -34,7 +34,7 @@ Ranges are expressed as Strings and are similar to the format of a Range object 
 
 Ranges can also be defined as "open ended."  Open ended ranges are defined with an integer followed by a '+' character.  These ranges are inclusive of the integer and any value higher then the integer.
 
-All ranges need to be expressed as Strings and must include parentheses.  "(1..10)" is considered to be a valid range. "1..10" is not considered to be a valid range (missing the parentheses.)
+All ranges need to be expressed as Strings and can include or exclude parentheses.  "(1..10)" and "1..10" are considered to be a valid range.
 
 ---
 

--- a/lib/spree_volume_pricing/engine.rb
+++ b/lib/spree_volume_pricing/engine.rb
@@ -14,10 +14,10 @@ module SpreeVolumePricing
           case self.count('.')
           when 2
             elements = self.split('..')
-            return Range.new(elements[0].from(1).to_i, elements[1].to_i)
+            return Range.new(elements[0].gsub('(','').to_i, elements[1].to_i)
           when 3
             elements = self.split('...')
-            return Range.new(elements[0].from(1).to_i, elements[1].to_i - 1)
+            return Range.new(elements[0].gsub('(','').to_i, elements[1].to_i - 1)
           else
             raise ArgumentError.new("Couldn't convert to Range: #{self}")
           end


### PR DESCRIPTION
In response to #81. 

This pull request makes it so you can pass in your numbers with or without parentheses

"(10..20)".to_range # 10..20

"10..20".to_range # 10..20

![image](https://cloud.githubusercontent.com/assets/4175592/8007859/baf6f880-0b5b-11e5-974c-226429978531.png)
