### PR TITLE
DRY out variant_decorator, add resolve_role

### DIFF
--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -2,8 +2,8 @@ Spree.user_class.class_eval do
 
   def resolve_role
 
-    if self.has_spree_role? Spree::Config.wholesale_role.to_sym
-      return Spree::Role.find_by name: Spree::Config.wholesale_role
+    if self.has_spree_role? Spree::Config.volume_pricing_role.to_sym
+      return Spree::Role.find_by name: Spree::Config.volume_pricing_role
     else
       return Spree::Role.find_by name: 'user'
     end

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,0 +1,11 @@
+Spree.user_class.class_eval do
+
+  def resolve_role
+
+    if self.has_spree_role? Spree::Config.wholesale_role.to_sym
+      return Spree::Role.find_by name: Spree::Config.wholesale_role
+    else
+      return Spree::Role.find_by name: 'user'
+    end
+  end
+end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -7,102 +7,97 @@ Spree::Variant.class_eval do
       volume_price[:amount].blank? && volume_price[:range].blank?
     }
 
-  def join_volume_prices
+  def join_volume_prices(user=nil)
     table = Spree::VolumePrice.arel_table
-    Spree::VolumePrice.where(table[:variant_id].eq(self.id).or(table[:volume_price_model_id].in(self.volume_price_models.ids))).order(position: :asc)
+
+    if user
+      Spree::VolumePrice.where(
+        (table[:variant_id].eq(self.id)
+          .or(table[:volume_price_model_id].in(self.volume_price_models.ids)))
+          .and(table[:role_id].eq(user.resolve_role))
+        )
+        .order(position: :asc)
+    else
+      Spree::VolumePrice.where(
+        (table[:variant_id]
+          .eq(self.id)
+          .or(table[:volume_price_model_id].in(self.volume_price_models.ids)))
+          .and(table[:role_id].eq(nil))
+        ).order(position: :asc)
+    end
   end
 
   # calculates the price based on quantity
   def volume_price(quantity, user=nil)
-    if self.join_volume_prices.count == 0
-      if !(self.product.master.join_volume_prices.count == 0) && Spree::Config.use_master_variant_volume_pricing
-        self.product.master.volume_price(quantity, user)
-      else
-        return self.price
-      end
-    else
-      self.join_volume_prices.each do |volume_price|
-        if volume_price.spree_role
-          return self.price unless user
-          return self.price unless user.has_spree_role? volume_price.spree_role.name.to_sym
-        end
-        if volume_price.include?(quantity)
-          case volume_price.discount_type
-          when 'price'
-            return volume_price.amount
-          when 'dollar'
-            return self.price - volume_price.amount
-          when 'percent'
-            return self.price * (1 - volume_price.amount)
-          end
-        end
-      end
-    end
-
-    # No price ranges matched.
-    price
+    compute_volume_price_quantities :volume_price, self.price, quantity, user
   end
 
   # return percent of earning
   def volume_price_earning_percent(quantity, user=nil)
-    if self.join_volume_prices.count == 0
-      if !(self.product.master.join_volume_prices.count == 0) && Spree::Config.use_master_variant_volume_pricing
-        self.product.master.volume_price_earning_percent(quantity, user)
-      else
-        return 0
-      end
-    else
-      self.join_volume_prices.each do |volume_price|
-        if volume_price.spree_role
-          return 0 unless user
-          return 0 unless user.has_spree_role? volume_price.spree_role.name.to_sym
-        end
-        if volume_price.include?(quantity)
-          case volume_price.discount_type
-          when 'price'
-            diff = self.price - volume_price.amount
-            return (diff * 100 / self.price).round
-          when 'dollar'
-            return (volume_price.amount * 100 / self.price).round
-          when 'percent'
-            return (volume_price.amount * 100).round
-          end
-        end
-      end
-    end
-
-    # No price ranges matched.
-    0
+    compute_volume_price_quantities :volume_price_earning_percent, 0, quantity, user
   end
 
   # return amount of earning
   def volume_price_earning_amount(quantity, user=nil)
-    if self.join_volume_prices.count == 0
-      if !(self.product.master.join_volume_prices.count == 0) && Spree::Config.use_master_variant_volume_pricing
-        self.product.master.volume_price_earning_amount(quantity, user)
-      else
-        return 0
-      end
-    else
-      self.join_volume_prices.each do |volume_price|
-        if volume_price.spree_role
-          return 0 unless user
-          return 0 unless user.has_spree_role? volume_price.spree_role.name.to_sym
+    compute_volume_price_quantities :volume_price_earning_amount, 0, quantity, user
+  end
+
+  protected
+    def use_master_variant_volume_pricing?
+      Spree::Config.use_master_variant_volume_pricing && !(self.product.master.join_volume_prices.count == 0)
+    end
+
+    def compute_volume_price_quantities type, default_price, quantity, user
+      volume_prices = self.join_volume_prices user
+      if volume_prices.count == 0
+        if use_master_variant_volume_pricing?
+          self.product.master.send(type, quantity, user)
+        else
+          return default_price
         end
-        if volume_price.include?(quantity)
-          case volume_price.discount_type
-          when 'price'
-            return self.price - volume_price.amount
-          when 'dollar'
-            return volume_price.amount
-          when 'percent'
-            return self.price - (self.price * (1 - volume_price.amount))
+      else
+        volume_prices.each do |volume_price|
+          if volume_price.include?(quantity)
+            return self.send "compute_#{type}".to_sym, volume_price
           end
         end
+
+        # No price ranges matched.
+        default_price
       end
     end
 
-    # No price ranges matched.
-    0
-  end
+    def compute_volume_price volume_price
+      case volume_price.discount_type
+      when 'price'
+        return volume_price.amount
+      when 'dollar'
+        return self.price - volume_price.amount
+      when 'percent'
+        return self.price * (1 - volume_price.amount)
+      end
+    end
+
+    def compute_volume_price_earning_percent volume_price
+      case volume_price.discount_type
+      when 'price'
+        diff = self.price - volume_price.amount
+        return (diff * 100 / self.price).round
+      when 'dollar'
+        return (volume_price.amount * 100 / self.price).round
+      when 'percent'
+        return (volume_price.amount * 100).round
+      end
+    end
+
+    def compute_volume_price_earning_amount volume_price
+      case volume_price.discount_type
+      when 'price'
+        return self.price - volume_price.amount
+      when 'dollar'
+        return volume_price.amount
+      when 'percent'
+        return self.price - (self.price * (1 - volume_price.amount))
+      end
+    end
 end

--- a/lib/spree_volume_pricing/engine.rb
+++ b/lib/spree_volume_pricing/engine.rb
@@ -7,6 +7,7 @@ module SpreeVolumePricing
     initializer "spree_volume_pricing.preferences", before: "spree.environment" do |app|
       Spree::AppConfiguration.class_eval do
         preference :use_master_variant_volume_pricing, :boolean, :default => false
+        preference :wholesale_role, :string, :default => "wholesale"
       end
     end
 

--- a/lib/spree_volume_pricing/engine.rb
+++ b/lib/spree_volume_pricing/engine.rb
@@ -7,7 +7,7 @@ module SpreeVolumePricing
     initializer "spree_volume_pricing.preferences", before: "spree.environment" do |app|
       Spree::AppConfiguration.class_eval do
         preference :use_master_variant_volume_pricing, :boolean, :default => false
-        preference :wholesale_role, :string, :default => "wholesale"
+        preference :volume_pricing_role, :string, :default => "wholesale"
       end
     end
 

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Spree::LineItem, type: :model do
 
   it 'updates the line item price when the quantity changes to match a range and role matches' do
     @order.user.spree_roles << @role
+    Spree::Config.wholesale_role = @role.name
     expect(@order.user.has_spree_role? @role.name.to_sym).to be(true)
     @variant.volume_prices.first.update(role_id: @role.id)
     expect(@line_item.price.to_f).to be(10.00)

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Spree::LineItem, type: :model do
 
   it 'updates the line item price when the quantity changes to match a range and role matches' do
     @order.user.spree_roles << @role
-    Spree::Config.wholesale_role = @role.name
+    Spree::Config.volume_pricing_role = @role.name
     expect(@order.user.has_spree_role? @role.name.to_sym).to be(true)
     @variant.volume_prices.first.update(role_id: @role.id)
     expect(@line_item.price.to_f).to be(10.00)

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'uses the volume price when it does match a range and role' do
         @user.spree_roles << @role
-        Spree::Config.wholesale_role = @role.name
+        Spree::Config.volume_pricing_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price(10, @user).to_f).to be(9.00)
       end
@@ -50,7 +50,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'gives percent of earning if role matches' do
         @user.spree_roles << @role
-        Spree::Config.wholesale_role = @role.name
+        Spree::Config.volume_pricing_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price_earning_percent(10, @user)).to be(10)
       end
@@ -77,7 +77,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'gives amount earning if role matches' do
         @user.spree_roles << @role
-        Spree::Config.wholesale_role = @role.name
+        Spree::Config.volume_pricing_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price_earning_amount(10, @user)).to eq(1)
       end
@@ -129,7 +129,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'uses the volume price when it does match a range and role' do
         @user.spree_roles << @role
-        Spree::Config.wholesale_role = @role.name
+        Spree::Config.volume_pricing_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price(10, @user).to_f).to be(9.00)
       end
@@ -146,7 +146,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'gives percent of earning if role matches' do
         @user.spree_roles << @role
-        Spree::Config.wholesale_role = @role.name
+        Spree::Config.volume_pricing_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price_earning_percent(10, @user)).to be(10)
       end
@@ -173,7 +173,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'gives amount earning if role matches' do
         @user.spree_roles << @role
-        Spree::Config.wholesale_role = @role.name
+        Spree::Config.volume_pricing_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price_earning_amount(10, @user)).to eq(1)
       end
@@ -225,7 +225,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'uses the volume price when it does match a range and role' do
         @user.spree_roles << @role
-        Spree::Config.wholesale_role = @role.name
+        Spree::Config.volume_pricing_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price(10, @user).to_f).to be(9.00)
       end
@@ -239,7 +239,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'gives amount earning if role matches' do
         @user.spree_roles << @role
-        Spree::Config.wholesale_role = @role.name
+        Spree::Config.volume_pricing_role = @role.name
         expect(@variant.volume_price_earning_percent(10)).to be(10)
         @variant_five = create :variant, price: 10
         @variant_five.volume_prices.create! amount: 0.5, discount_type: 'percent', range: '(1+)'
@@ -272,7 +272,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'gives amount earning if role matches' do
         @user.spree_roles << @role
-        Spree::Config.wholesale_role = @role.name
+        Spree::Config.volume_pricing_role = @role.name
         expect(@variant.volume_price_earning_amount(10)).to eq(1)
         @variant_five = create :variant, price: 10
         @variant_five.volume_prices.create! amount: 0.5, discount_type: 'percent', range: '(1+)'

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'uses the volume price when it does match a range and role' do
         @user.spree_roles << @role
+        Spree::Config.wholesale_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price(10, @user).to_f).to be(9.00)
       end
@@ -49,6 +50,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'gives percent of earning if role matches' do
         @user.spree_roles << @role
+        Spree::Config.wholesale_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price_earning_percent(10, @user)).to be(10)
       end
@@ -75,6 +77,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'gives amount earning if role matches' do
         @user.spree_roles << @role
+        Spree::Config.wholesale_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price_earning_amount(10, @user)).to eq(1)
       end
@@ -126,6 +129,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'uses the volume price when it does match a range and role' do
         @user.spree_roles << @role
+        Spree::Config.wholesale_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price(10, @user).to_f).to be(9.00)
       end
@@ -142,6 +146,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'gives percent of earning if role matches' do
         @user.spree_roles << @role
+        Spree::Config.wholesale_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price_earning_percent(10, @user)).to be(10)
       end
@@ -168,6 +173,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'gives amount earning if role matches' do
         @user.spree_roles << @role
+        Spree::Config.wholesale_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price_earning_amount(10, @user)).to eq(1)
       end
@@ -219,6 +225,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'uses the volume price when it does match a range and role' do
         @user.spree_roles << @role
+        Spree::Config.wholesale_role = @role.name
         @variant.volume_prices.first.update(role_id: @role.id)
         expect(@variant.volume_price(10, @user).to_f).to be(9.00)
       end
@@ -232,6 +239,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'gives amount earning if role matches' do
         @user.spree_roles << @role
+        Spree::Config.wholesale_role = @role.name
         expect(@variant.volume_price_earning_percent(10)).to be(10)
         @variant_five = create :variant, price: 10
         @variant_five.volume_prices.create! amount: 0.5, discount_type: 'percent', range: '(1+)'
@@ -264,6 +272,7 @@ RSpec.describe Spree::Variant, type: :model do
 
       it 'gives amount earning if role matches' do
         @user.spree_roles << @role
+        Spree::Config.wholesale_role = @role.name
         expect(@variant.volume_price_earning_amount(10)).to eq(1)
         @variant_five = create :variant, price: 10
         @variant_five.volume_prices.create! amount: 0.5, discount_type: 'percent', range: '(1+)'


### PR DESCRIPTION
@juancroca, please take a look at this PR.

Two things

  1. DRY out the variant_decorator a bit
  2. Re add the resolve_role method on the user
   
All volume_prices are being fetched and computed for a given user with multiple roles.

For Ex. if a user had both a `user` role and a `wholesale` role volume_prices would be calculated for both the `user` and `wholesale` roles.

Additionally, I scoped the join_volume_prices query so that it only retrieved relevant prices for the user. This is a performance optimization.