### PR TITLE
vprice should always be applied if it exists and shoulda matchers configured

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -10,18 +10,10 @@ Spree::LineItem.class_eval do
   define_method(:copy_price) do
     old_copy_price.bind(self).call
     return unless variant
-
-    if variant
-      if changed? && changes.keys.include?('quantity')
-        vprice = variant.volume_price(quantity, order.user)
-        if price.present? && vprice && vprice <= variant.price
-          self.price = vprice and return
-        end
-      end
-
-      self.price = variant.price if price.nil?
+    
+    vprice = variant.volume_price(quantity, order.user)
+    if vprice
+      self.price = vprice
     end
-
-    self.price = variant.price if price.nil?
   end
 end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -14,7 +14,7 @@ Spree::LineItem.class_eval do
     if variant
       if changed? && changes.keys.include?('quantity')
         vprice = variant.volume_price(quantity, order.user)
-        if price.present? && vprice <= variant.price
+        if price.present? && vprice && vprice <= variant.price
           self.price = vprice and return
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,9 @@ RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.syntax = :expect
   end
+  
+  config.include(Shoulda::Matchers::ActiveModel, type: :model)
+  config.include(Shoulda::Matchers::ActiveRecord, type: :model)
 end
 
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |file| require file }


### PR DESCRIPTION
I haven't locked the Shoulda Matchers version in the gemspec, but I suspect that the gem configurations have changed since the last commit in master branch (that's why it wasn't failing then). Also, about the correction, the problem is that during the checkout process, `copy_price` callback is called even if the quantity hasn't changed, meaning that the price without volume pricing is re-applied.