### PR TITLE
Added Deface as dependency

### DIFF
--- a/spree_volume_pricing.gemspec
+++ b/spree_volume_pricing.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'spree_core', '>= 3.1.0', '< 5.0'
   s.add_runtime_dependency 'spree_extension'
+  s.add_runtime_dependency 'deface', '~> 1.0'
 
   s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'capybara'


### PR DESCRIPTION
Since Spree 4.0 [doesn't require deface](https://github.com/spree/spree/pull/9394) we need to require it here